### PR TITLE
Bump egui/eframe to 0.30 and smallvec to 2.0.0-alpha.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 
 [workspace]
-package.version = "0.6.0"
+package.version = "0.7.0"
 package.edition = "2021"
 package.license = "MIT OR Apache-2.0"
 
@@ -15,7 +15,7 @@ description = "Trait and derive macro for exposing value editing in egui"
 derive = ["dep:egui-probe-proc"]
 
 [dependencies]
-egui-probe-proc = { path = "proc", version = "=0.6.0", optional = true }
+egui-probe-proc = { path = "proc", version = "=0.7.0", optional = true }
 egui = { version = "0.30" }
 
 smallvec1 = { package = "smallvec", version = "1", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ derive = ["dep:egui-probe-proc"]
 
 [dependencies]
 egui-probe-proc = { path = "proc", version = "=0.6.0", optional = true }
-egui = { version = "0.29" }
+egui = { version = "0.30" }
 
 smallvec1 = { package = "smallvec", version = "1", features = [
     "const_generics",
 ], optional = true }
-smallvec2 = { package = "smallvec", version = "2.0.0-alpha.7", optional = true }
+smallvec2 = { package = "smallvec", version = "2.0.0-alpha.9", optional = true }
 hashbrown = { version = "0.15", optional = true }
 
 [dev-dependencies]
-eframe = "0.29"
+eframe = "0.30"
 edict = "1.0.0-rc6"
 
 [[example]]


### PR DESCRIPTION
Very straightforward this time around, no breaking changes affect any of the code in this repo as far as I can tell.