### PR TITLE
Add default value support

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -19,7 +19,7 @@ fn custom_probe(_: &mut Foo, ui: &mut egui::Ui, _: &egui_probe::Style) -> egui::
     ui.label("This is custom probe")
 }
 
-#[derive(EguiProbe)]
+#[derive(EguiProbe, Clone)]
 #[egui_probe(transparent)]
 struct UpTo7(#[egui_probe(range = ..=7)] u32);
 
@@ -69,6 +69,7 @@ struct InnerValue {
     hash_brown: hashbrown::HashMap<u8, f32>,
 }
 
+
 #[derive(EguiProbe)]
 struct DemoValue {
     boolean: bool,
@@ -81,7 +82,8 @@ struct DemoValue {
     #[egui_probe(range = 22..=55)]
     range: usize,
 
-    range_to: UpTo7,
+    #[egui_probe(default=UpTo7(5))]
+    maybe_range_to: Option<UpTo7>,
 
     #[egui_probe(range = 50..)]
     range_from: u8,
@@ -95,6 +97,7 @@ struct DemoValue {
     #[egui_probe(name = "renamed ^_^")]
     renamed: u8,
 
+    #[egui_probe(default = true)]
     maybe_boolean: Option<bool>,
 
     inner: InnerValue,
@@ -128,7 +131,7 @@ impl EguiProbeDemoApp {
                 boolean_toggle: false,
                 float: 0.0,
                 range: 22,
-                range_to: UpTo7(0),
+                maybe_range_to: Some(UpTo7(0)),
                 range_from: 100,
                 angle: 0.0,
                 custom: Foo,

--- a/proc/src/probe.rs
+++ b/proc/src/probe.rs
@@ -6,6 +6,7 @@ use syn::{spanned::Spanned, LitStr};
 proc_easy::easy_token!(skip);
 proc_easy::easy_token!(with);
 proc_easy::easy_token!(range);
+proc_easy::easy_token!(default);
 proc_easy::easy_token!(name);
 proc_easy::easy_token!(multiline);
 proc_easy::easy_token!(snake_case);
@@ -113,6 +114,13 @@ proc_easy::easy_argument_value! {
         expr: syn::Expr,
     }
 }
+proc_easy::easy_argument_value! {
+    struct Default {
+        default: default,
+
+        expr: syn::Expr,
+    }
+}
 
 proc_easy::easy_argument_value! {
     struct Name {
@@ -124,6 +132,7 @@ proc_easy::easy_argument_value! {
 proc_easy::easy_argument_group! {
     enum FieldProbeKind {
         Range(Range),
+        Default(Default),
         With(With),
         ProbeAs(ProbeAs),
         Multiline(multiline),
@@ -142,6 +151,7 @@ impl FieldProbeKind {
             FieldProbeKind::With(with) => with.with.span(),
             FieldProbeKind::ProbeAs(probe_as) => probe_as.probe_as.span(),
             FieldProbeKind::Range(range) => range.range.span(),
+            FieldProbeKind::Default(default) => default.default.span(),
             FieldProbeKind::Multiline(multiline) => multiline.span(),
             FieldProbeKind::ToggleSwitch(toggle_switch) => toggle_switch.span(),
             FieldProbeKind::Frozen(frozen) => frozen.span(),
@@ -163,6 +173,7 @@ impl FieldProbeKind {
             FieldProbeKind::With(_) => format_error!("with"),
             FieldProbeKind::ProbeAs(_) => format_error!("as"),
             FieldProbeKind::Range(_) => format_error!("range"),
+            FieldProbeKind::Default(_) => format_error!("default"),
             FieldProbeKind::Multiline(_) => format_error!("multiline"),
             FieldProbeKind::ToggleSwitch(_) => format_error!("toggle_switch"),
             FieldProbeKind::Frozen(_) => format_error!("frozen"),
@@ -304,6 +315,12 @@ fn field_probe(idx: usize, field: &syn::Field) -> syn::Result<Option<proc_macro2
             let expr = range.expr;
             quote::quote_spanned! {field.span() =>
                 &mut probe_range(#expr, #binding)
+            }
+        }
+        Some(FieldProbeKind::Default(default)) => {
+            let expr = default.expr;
+            quote::quote_spanned! {field.span() =>
+                &mut probe_default(#expr, #binding)
             }
         }
         Some(FieldProbeKind::Multiline(_)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,8 @@ pub fn angle(value: &mut f32) -> impl EguiProbe + '_ {
 }
 
 pub mod customize {
+    use crate::option::EguiProbeDefault;
+
     use super::{
         boolean::ToggleSwitch,
         collections::EguiProbeFrozen,
@@ -302,6 +304,14 @@ pub mod customize {
         EguiProbeRange<'a, T, R>: EguiProbe,
     {
         EguiProbeRange { value, range }
+    }
+
+    #[inline(always)]
+    pub fn probe_default<'a, T>(default: T, value: &'a mut Option<T>) -> EguiProbeDefault<'a, T>
+    where
+    T: EguiProbe+Clone,
+    {
+        EguiProbeDefault { value, default }
     }
 
     #[inline(always)]
@@ -434,6 +444,9 @@ fn test_all_attributes() {
 
         #[egui_probe(rgba_unmultiplied)]
         m: [f32; 4],
+
+        #[egui_probe(default = "Hello World".to_string())]
+        n: Option<String>,
     }
 
     #[derive(EguiProbe)]

--- a/src/option.rs
+++ b/src/option.rs
@@ -67,3 +67,29 @@ pub fn option_probe_with<T>(
 
     r
 }
+
+/// Bundles value and a range to show probbing UI to edit the value in that range.
+pub struct EguiProbeDefault<'a, T:EguiProbe+Clone> {
+    pub value: &'a mut Option<T>,
+    pub default: T,
+}
+
+impl<T:EguiProbe+Clone> EguiProbe for EguiProbeDefault<'_, T> {
+    #[inline(always)]
+    fn probe(&mut self, ui: &mut egui::Ui, style: &Style) -> egui::Response {
+        option_probe_with(self.value, ui, style, ||self.default.clone(), |value, ui, style| {
+            value.probe(ui, style)
+        })
+    }
+
+    #[inline(always)]
+    fn iterate_inner(
+        &mut self,
+        ui: &mut egui::Ui,
+        f: &mut dyn FnMut(&str, &mut egui::Ui, &mut dyn EguiProbe),
+    ) {
+        if let Some(value) = self.value {
+            value.iterate_inner(ui, f);
+        }
+    }
+}


### PR DESCRIPTION
Hi, 

I added a first naive support for default values. The syntax looks something like this:
```rust
#[derive(EguiProbe)]
struct MyStruct{
    #[egui_probe(default = 42)]
    field:Option<u32>
}
```

The way it is implemented right now does not allow it to be combined with other FieldProbeKinds like `multiline` or `range`. 
I am not sure if this is needed, as you could use a nested type in these cases.

Adding support for combination with other probe kinds would be more involved. 