### PR TITLE
EguiProbe for sync code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rust-version.workspace = true
 
 [features]
 derive = ["dep:egui-probe-proc"]
+parking_lot = ["dep:parking_lot"]
 
 [dependencies]
 egui-probe-proc = { path = "proc", version = "=0.9.1", optional = true }
@@ -29,6 +30,8 @@ smallvec1 = { package = "smallvec", version = "1", features = [
 smallvec2 = { package = "smallvec", version = "2.0.0-alpha.11", optional = true }
 hashbrown = { version = "0.16", optional = true }
 
+parking_lot = { version = "0.12", optional = true }
+
 [dev-dependencies]
 eframe = "0.33"
 edict = "1.0.0-rc8"
@@ -39,6 +42,10 @@ required-features = ["derive"]
 
 [[example]]
 name = "edict"
+required-features = ["derive"]
+
+[[example]]
+name = "sync"
 required-features = ["derive"]
 
 [package.metadata.docs.rs]

--- a/examples/sync.rs
+++ b/examples/sync.rs
@@ -1,0 +1,68 @@
+use std::{
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use egui_probe::{EguiProbe, Probe};
+
+#[derive(Debug, Clone, EguiProbe, PartialEq, Default)]
+pub struct Person {
+    name: String,
+    age: u32,
+}
+
+#[derive(Debug, Clone, EguiProbe)]
+pub struct Shared {
+    /// this value will be shared between two threads, one will be updated by the ui
+    value: Arc<RwLock<Person>>,
+}
+fn main() {
+    let shared = Shared {
+        value: Arc::new(RwLock::new(Person::default())),
+    };
+    let other = shared.clone();
+    std::thread::spawn(move || {
+        loop {
+            {
+                let r = other.value.read().unwrap();
+                println!("value is: {r:#?}");
+            }
+            std::thread::sleep(Duration::from_secs(1));
+            {
+                other.value.write().unwrap().name += "a";
+            }
+            std::thread::sleep(Duration::from_secs(1));
+        }
+    });
+    let native_options = eframe::NativeOptions::default();
+    eframe::run_native(
+        "egui-probe demo app",
+        native_options,
+        Box::new(|cc| Ok(Box::new(EguiProbeDemoApp::new(cc, shared)))),
+    )
+    .unwrap();
+}
+
+struct EguiProbeDemoApp {
+    value: Shared,
+}
+
+impl EguiProbeDemoApp {
+    fn new(_cc: &eframe::CreationContext<'_>, shared: Shared) -> Self {
+        EguiProbeDemoApp { value: shared }
+    }
+}
+
+impl eframe::App for EguiProbeDemoApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::TopBottomPanel::top("header").show(ctx, |ui| {
+            egui::widgets::global_theme_preference_switch(ui);
+        });
+
+        egui::CentralPanel::default().show(ctx, |ui| {
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                Probe::new(&mut self.value).show(ui);
+            });
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ mod hashbrown;
 mod map;
 mod num;
 mod option;
+mod rwlock;
 mod set;
 #[cfg(any(feature = "smallvec1", feature = "smallvec2"))]
 mod small_vec;
@@ -114,6 +115,7 @@ mod vec;
 mod widget;
 
 pub use egui;
+pub use rwlock::ListOptions;
 
 pub use self::{
     boolean::toggle_switch,

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -1,0 +1,132 @@
+use std::{
+    fmt::{Debug, Display},
+    sync::{Arc, RwLock, Weak},
+};
+
+use crate::{EguiProbe, Probe};
+
+#[cfg(feature = "parking_lot")]
+mod parking_lot;
+
+impl<T> EguiProbe for RwLock<T>
+where
+    T: Clone + PartialEq + EguiProbe + Debug,
+{
+    fn probe(&mut self, ui: &mut egui::Ui, style: &crate::Style) -> egui::Response {
+        let mut cloned = { self.read().unwrap().clone() };
+        let probe = cloned.probe(ui, style);
+        let changed = {
+            let guard = self.read().unwrap();
+            cloned != *guard
+        };
+        if probe.changed() || changed {
+            {
+                *self.write().unwrap() = cloned;
+            }
+        }
+        probe
+    }
+    fn iterate_inner(
+        &mut self,
+        ui: &mut egui::Ui,
+        f: &mut dyn FnMut(&str, &mut egui::Ui, &mut dyn EguiProbe),
+    ) {
+        let mut cloned = { self.read().unwrap().clone() };
+        cloned.iterate_inner(ui, f);
+    }
+}
+
+impl<T> EguiProbe for Arc<RwLock<T>>
+where
+    T: Clone + PartialEq + EguiProbe + Debug,
+{
+    fn probe(&mut self, ui: &mut egui::Ui, style: &crate::Style) -> egui::Response {
+        let mut cloned = { self.read().unwrap().clone() };
+        let probe = cloned.probe(ui, style);
+        let changed = { cloned != *self.read().unwrap() };
+        if probe.changed() || changed {
+            {
+                *self.write().unwrap() = cloned;
+            }
+        }
+        probe
+    }
+
+    fn iterate_inner(
+        &mut self,
+        ui: &mut egui::Ui,
+        f: &mut dyn FnMut(&str, &mut egui::Ui, &mut dyn EguiProbe),
+    ) {
+        let mut cloned = { self.read().unwrap().clone() };
+        cloned.iterate_inner(ui, f);
+        let changed = {
+            let guard = self.read().unwrap();
+            cloned != *guard
+        };
+        if changed {
+            *self.write().unwrap() = cloned;
+        }
+    }
+}
+
+/// The [`Weak`] acts like an [`Option`]. If the [`Weak`] cannot be upgraded,
+/// it is considered [`None`]. If it is [`None`] `T` is used to provide a list
+/// of possible values that may be selected using [`ListOptions`].
+/// [`ListOptions::resolve`] then returns the new [`Weak`] value that gets updated.
+impl<T> EguiProbe for Weak<RwLock<T>>
+where
+    T: EguiProbe + PartialEq + Clone + ListOptions + Debug,
+    T: ListOptions<Resolve = T, Lock = RwLock<T>>,
+{
+    fn probe(&mut self, ui: &mut egui::Ui, style: &crate::Style) -> egui::Response {
+        match self.upgrade() {
+            Some(mut value) => {
+                let mut res = Probe::new(&mut value).show(ui);
+                if ui.button(style.remove_button_text()).clicked() {
+                    *self = Weak::new();
+                    res.mark_changed();
+                }
+                res
+            }
+            None => {
+                let ctx = ui.ctx().clone();
+                let options = T::list_available(&ctx);
+
+                // Use a persistent ID for the combobox state
+                let combo_id = ui.make_persistent_id("weak_select_combo");
+
+                let response = egui::ComboBox::from_id_salt(combo_id).show_ui(ui, |ui| {
+                    for option in options {
+                        let res = ui.selectable_label(false, option.to_string());
+                        if res.clicked() {
+                            return Some(option);
+                        }
+                    }
+                    None
+                });
+
+                if let Some(Some(updated)) = response.inner {
+                    *self = T::resolve(&ctx, updated);
+                }
+                response.response
+            }
+        }
+    }
+}
+
+/// A helper trait used togehter with [`Weak`] to list possibile values that
+/// can be selected
+// perhaps this can also be used in Option instead of the Default bound
+pub trait ListOptions {
+    /// The type of item that can be selected. It must implement [`Display`]
+    /// since it is represented as [`selectable_label`](egui::Ui::selectable_label)
+    /// Then the [`ListOptions::resolve`] should return an [`RwLock<T>`] where
+    /// `T` `=` [`ListOptions::Resolve`]
+    type Item: Display;
+    type Resolve;
+    /// RwLock<Self::Resolve>
+    type Lock;
+    fn list_available(ctx: &egui::Context) -> impl Iterator<Item = Self::Item>;
+    /// resolve the selection
+    fn resolve(ctx: &egui::Context, value: Self::Item) -> Weak<Self::Lock>;
+}

--- a/src/rwlock/parking_lot.rs
+++ b/src/rwlock/parking_lot.rs
@@ -1,0 +1,110 @@
+use std::{
+    fmt::Debug,
+    sync::{Arc, Weak},
+};
+
+use parking_lot::RwLock;
+
+use crate::{EguiProbe, ListOptions, Probe};
+
+impl<T> EguiProbe for RwLock<T>
+where
+    T: Clone + PartialEq + EguiProbe + Debug,
+{
+    fn probe(&mut self, ui: &mut egui::Ui, style: &crate::Style) -> egui::Response {
+        let mut cloned = { self.read().clone() };
+        let probe = cloned.probe(ui, style);
+        let changed = {
+            let guard = self.read();
+            cloned != *guard
+        };
+        if probe.changed() || changed {
+            {
+                *self.write() = cloned;
+            }
+        }
+        probe
+    }
+    fn iterate_inner(
+        &mut self,
+        ui: &mut egui::Ui,
+        f: &mut dyn FnMut(&str, &mut egui::Ui, &mut dyn EguiProbe),
+    ) {
+        let mut cloned = { self.read().clone() };
+        cloned.iterate_inner(ui, f);
+    }
+}
+
+impl<T> EguiProbe for Arc<RwLock<T>>
+where
+    T: Clone + PartialEq + EguiProbe + Debug,
+{
+    fn probe(&mut self, ui: &mut egui::Ui, style: &crate::Style) -> egui::Response {
+        let mut cloned = { self.read().clone() };
+        let probe = cloned.probe(ui, style);
+        let changed = { cloned != *self.read() };
+        if probe.changed() || changed {
+            {
+                *self.write() = cloned;
+            }
+        }
+        probe
+    }
+
+    fn iterate_inner(
+        &mut self,
+        ui: &mut egui::Ui,
+        f: &mut dyn FnMut(&str, &mut egui::Ui, &mut dyn EguiProbe),
+    ) {
+        let mut cloned = { self.read().clone() };
+        cloned.iterate_inner(ui, f);
+        let changed = {
+            let guard = self.read();
+            cloned != *guard
+        };
+        if changed {
+            *self.write() = cloned;
+        }
+    }
+}
+
+impl<T> EguiProbe for Weak<RwLock<T>>
+where
+    T: EguiProbe + PartialEq + Clone + ListOptions + Debug,
+    T: ListOptions<Resolve = T, Lock = RwLock<T>>,
+{
+    fn probe(&mut self, ui: &mut egui::Ui, style: &crate::Style) -> egui::Response {
+        match self.upgrade() {
+            Some(mut value) => {
+                let mut res = Probe::new(&mut value).show(ui);
+                if ui.button(style.remove_button_text()).clicked() {
+                    *self = Weak::new();
+                    res.mark_changed();
+                }
+                res
+            }
+            None => {
+                let ctx = ui.ctx().clone();
+                let options = T::list_available(&ctx);
+
+                // Use a persistent ID for the combobox state
+                let combo_id = ui.make_persistent_id("weak_select_combo");
+
+                let response = egui::ComboBox::from_id_salt(combo_id).show_ui(ui, |ui| {
+                    for option in options {
+                        let res = ui.selectable_label(false, option.to_string());
+                        if res.clicked() {
+                            return Some(option);
+                        }
+                    }
+                    None
+                });
+
+                if let Some(Some(updated)) = response.inner {
+                    *self = T::resolve(&ctx, updated);
+                }
+                response.response
+            }
+        }
+    }
+}

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -184,24 +184,26 @@ impl ProbeLayout {
 /// For simple values it will show a probe UI for it.
 /// For complex values it will header with collapsible body.
 #[must_use = "You should call .show()"]
-pub struct Probe<'a, T> {
+pub struct Probe<'a> {
     header: Option<egui::WidgetText>,
     style: Style,
-    value: &'a mut T,
+    value: &'a mut dyn EguiProbe,
 }
 
-impl<'a, T> Probe<'a, T>
-where
-    T: EguiProbe,
-{
+impl<'a> Probe<'a> {
     /// Creates a new `Probe` widget.
-    pub fn new(value: &'a mut T) -> Self {
+    pub fn new(value: &'a mut dyn EguiProbe) -> Self {
         Probe {
             // id_salt: egui::Id::new(label.text()),
             header: None,
             style: Style::default(),
             value,
         }
+    }
+
+    pub fn with_style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
     }
 
     pub fn with_header(mut self, label: impl Into<WidgetText>) -> Self {


### PR DESCRIPTION
For `ListOptions` what I do is access a global "datastore" struct via Context which stores the actual `Arc<RwLock<T>>` types